### PR TITLE
chore: update V compiler compatibility to V 0.4.8 14b1a14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Consul-Template Plugin: string2files
 Lightweight Consul-Template plugin that (basically) write string to file(s). Created because I need easy way to write multiple files from Consul KV tree with only single template :v:.
 
-Build with V language compiler: `V 0.2.4 8315e82`.
+*(Update 2024-10-26) Build with V language compiler: `V 0.4.8 14b1a14`*
 
 ### Credits
 This plugin heavily inspired by:
@@ -76,7 +76,7 @@ For Example: given below items on Consul KV & Vault Secret:
 - Vault Secret:
   ```
   secret/myservices
-      │   app.conf        
+      │   app.conf
       |      - app.token    "s3cr3t-t0k3n"
       │
       └─── db/db.conf

--- a/filewriter/filewriter.v
+++ b/filewriter/filewriter.v
@@ -6,12 +6,10 @@ import log
 pub struct FileWriter {
 mut:
 	ofile  os.File
-	logger log.Log = log.Log{
-		level: .info
-	}
 pub mut:
 	path       string
 	content    string
 	is_force   bool
 	is_newline bool
+	logger log.Log = log.Log{}
 }

--- a/filewriter/filewriter_explode.v
+++ b/filewriter/filewriter_explode.v
@@ -13,7 +13,7 @@ pub fn explode_data(args map[string]string, flags map[string]bool) {
 	}
 	if content_split.len % 2 != 0 {
 		fw.logger.warn('(${content_split}) k/v pair is not even, ommiting uncomplete k/v.')
-		content_split = content_split[0..(content_split.len - 1)]
+		content_split = content_split[0..(content_split.len - 1)].clone()
 	}
 	// Loops splited data
 	for i := 0; i < content_split.len; i += 2 {

--- a/string2files.v
+++ b/string2files.v
@@ -38,14 +38,14 @@ fn main() {
 		flag: .bool
 		name: 'force'
 		abbrev: 'f'
-		value: ['false']
+		default_value: ['false']
 		description: 'Create new directory/file from <path-file> if not exist.'
 	}
 	cli_flags << Flag{
 		flag: .bool
 		name: 'new-line'
 		abbrev: 'nl'
-		value: ['false']
+		default_value: ['false']
 		description: 'Add new line in the end of file.'
 	}
 	append_cmd.add_flags(cli_flags)
@@ -71,6 +71,7 @@ fn append_func(cmd Command) ! {
 		is_force: flag_force
 		is_newline: flag_newline
 	}
+	fw.logger.set_level(.info)
 	fw.append_file()
 }
 


### PR DESCRIPTION
## Changes

Small maintenance update:
- chore: update V compiler compatibility to `V 0.4.8 14b1a14` (previously built on `0.3.3 cdc0159`).